### PR TITLE
Travis CI: Add Python 3.8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-matrix:
+jobs:
   include:
+    - python: 3.8
+      env: TOXENV=py38
     - python: 3.7
-      dist: xenial
       env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36
@@ -13,11 +14,9 @@ matrix:
       env: TOXENV=py35
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.7
-      dist: xenial
+    - python: 3.8
       env: TOXENV=flake8
-    - python: 3.7
-      dist: xenial
+    - python: 3.8
       env: TOXENV=docs
   allow_failures:
     - env: TOXENV=docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27, py35, py36, py37, flake8
+envlist = py27, py35, py36, py37, py38, flake8
 
 [testenv:flake8]
-basepython=python3.7
+basepython=python3.8
 deps=flake8
 commands=flake8 .
 
@@ -19,7 +19,7 @@ commands =
 
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 changedir = docs
 deps = 
     -r{toxinidir}/requirements_docs.txt


### PR DESCRIPTION
Output at https://travis-ci.org/earswideopen/ewo-core/pull_requests

This probably needs to be migrated from travis-ci.org —> travis-ci.com